### PR TITLE
Fixed Dialog plugin return value

### DIFF
--- a/src/plugin/dialog.rs
+++ b/src/plugin/dialog.rs
@@ -2,7 +2,7 @@
 //!
 
 use js_sys::Array;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 
 use crate::utils::ArrayIterator;
@@ -15,6 +15,7 @@ struct DialogFilter<'a> {
 /// The FileResponse (from the [Tauri v2 API](https://docs.rs/tauri-plugin-dialog/latest/tauri_plugin_dialog/struct.FileResponse.html))
 ///
 /// Constructs a FileResponse object that is returned when the FileDialog returns a file
+#[derive(Serialize, Deserialize, Debug, Clone, Hash)]
 pub struct FileResponse {
     pub base64_data: Option<String>,
     pub duration: Option<u64>,
@@ -146,7 +147,7 @@ impl<'a> FileDialogBuilder<'a> {
     pub async fn pick_file(&self) -> crate::Result<Option<FileResponse>> {
         let raw = inner::open(serde_wasm_bindgen::to_value(&self)?).await?;
         // Deserialize into FileData
-        let file_data: FileData = serde_wasm_bindgen::from_value(raw)?;
+        let file_data: FileResponse = serde_wasm_bindgen::from_value(raw)?;
         // Return the file data wrapped in Some
         Ok(Some(file_data))
     }


### PR DESCRIPTION
## The issue
When using the Tauri dialog plugin, the returned value changes based on if the user chooses a file or a directory.
Here an example:
**Choosing a file:**
```js
Selected file: Err(Serde("Error: invalid type: JsValue(Object({\"base64Data\":null,\"duration\":null,\"height\":null,\"width\":null,\"mimeType\":null,\"modifiedAt\":1712222599510,\"name\":\"README.md\",\"path\":\"C:\\\\Users\\\\benbe\\\\Documents\\\\Coding\\\\Raspirus\\\\docs\\\\README.md\",\"size\":3283})), expected path string"))
```
**and choosing a directory:**
```js
Selected folder: Ok(Some("C:\\Users\\benbe\\Documents\\Coding\\Raspirus\\docs\\overrides"))
```

The main difference being that when choosing a directory, you get the path directly, but when choosing a file, you get a [FileResponse object](https://docs.rs/tauri-plugin-dialog/latest/tauri_plugin_dialog/struct.FileResponse.html). This previously resulted in an Err. With this PR that should now be fixed. I tested the single file picker and it works.

## What I changed
I basically copied the FileResponse object from the Tauri documentation and tweaked the `pick_file` and `pick_files` functions to use the new object instead of PathBuf. The way I implemented it may not be the best way to do this, especially since the traits could be defined better, but it works for the `pick_file` function at least.